### PR TITLE
💥 wakealarm.sh is going to be put in /usr/local/bin instead of /usr/bin

### DIFF
--- a/scripts/install-crontabs.sh
+++ b/scripts/install-crontabs.sh
@@ -12,6 +12,6 @@ sudo chown root:root /etc/logrotate.d/cronlog.conf
 if [ ! -d /var/log/cron ]; then
     sudo mkdir -p /var/log/cron
 fi
-sudo cp "$SCRIPTS_DIR"/wakealarm.sh /usr/bin/
-sudo chmod 544 /usr/bin/wakealarm.sh
-sudo chown root:root /usr/bin/wakealarm.sh
+sudo cp "$SCRIPTS_DIR"/wakealarm.sh /usr/local/bin/
+sudo chmod 544 /usr/local/bin/wakealarm.sh
+sudo chown root:root /usr/local/bin/wakealarm.sh


### PR DESCRIPTION
## Description
It is common that self-made scripts are put in `/usr/local/bin`.

## References

- <https://askubuntu.com/questions/465109/where-should-i-put-my-script-so-that-i-can-run-it-by-a-direct-command>
- <https://serverfault.com/questions/287724/can-i-place-my-script-in-usr-bin>
- <https://linuc.org/study/knowledge/544/> (written in Japanese)